### PR TITLE
Update dogewalker/doge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/dogeorg/indexer
 go 1.21
 
 require (
-	github.com/dogeorg/doge v0.1.2
-	github.com/dogeorg/dogewalker v0.0.6
+	github.com/dogeorg/doge v0.1.10
+	github.com/dogeorg/dogewalker v1.0.1
 	github.com/dogeorg/governor v1.0.5
 	github.com/dogeorg/storelib v0.0.5
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,12 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvw
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/dogeorg/doge v0.1.2 h1:ne1etzlj/ryQ3lCp2pF7kSDWj3dld9YsssumCmvK5vI=
 github.com/dogeorg/doge v0.1.2/go.mod h1:Q9/0XChJ8EA54OrhjkWm+ySEm0zZ5M7C38do/ZCnZuY=
+github.com/dogeorg/doge v0.1.10 h1:iSLjJXqDOW8pjOwahmQWGyBr1O7BvWzBcoddOZoskWM=
+github.com/dogeorg/doge v0.1.10/go.mod h1:Q9/0XChJ8EA54OrhjkWm+ySEm0zZ5M7C38do/ZCnZuY=
 github.com/dogeorg/dogewalker v0.0.6 h1:d7xIk56jUpP6Su7/rbSV7NaLMFsuNuzZ8Og5lOf9B+0=
 github.com/dogeorg/dogewalker v0.0.6/go.mod h1:yrAKdKjGLzY0Rj/4MY7kjmvOFCDaZXbjlmX5pIaOuMA=
+github.com/dogeorg/dogewalker v1.0.1 h1:y2Vmn0nDJQ/KkkzQGQ0TuH51/uNDWAw2Q6qab6V4DBQ=
+github.com/dogeorg/dogewalker v1.0.1/go.mod h1:Ib+ZWWQgRMKz6/8PmeLGMe4oyecok83iprz5+6ScoBo=
 github.com/dogeorg/governor v1.0.5 h1:XXdsKva4MvraaGZQo/8LqZIguIa3NkBSG454sIItfuo=
 github.com/dogeorg/governor v1.0.5/go.mod h1:+3y1e0TjLs963Sphk9svnzSXBlFdzQST/VNWzG6N6jw=
 github.com/dogeorg/storelib v0.0.5 h1:a3M2mW7nPMOPAd/75Jw9u1aSP3i7VABp1emhGP7bSyY=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dogeorg/doge"
 	"github.com/dogeorg/dogewalker/core"
+	walkerspec "github.com/dogeorg/dogewalker/spec"
 	"github.com/dogeorg/dogewalker/walker"
 	"github.com/dogeorg/governor"
 	"github.com/dogeorg/indexer/index"
@@ -76,7 +77,8 @@ func main() {
 
 	// TipChaser
 	zmqAddr := fmt.Sprintf("tcp://%v:%v", config.zmqHost, config.zmqPort)
-	zmqSvc, tipChanged := core.NewTipChaser(zmqAddr)
+	chainEvents := make(chan walkerspec.BlockchainEvent, 1)
+	zmqSvc := core.NewTipChaser(zmqAddr, chainEvents, false)
 	gov.Add("ZMQ", zmqSvc)
 
 	// Get the resume-point.
@@ -106,7 +108,7 @@ func main() {
 		Chain:              chain,
 		LastProcessedBlock: fromHash,
 		Client:             blockchain,
-		TipChanged:         tipChanged,
+		ChainEvents:        chainEvents,
 	})
 	gov.Add("Walk", walkSvc)
 


### PR DESCRIPTION
Updates dogewalker/doge so that block [`6225155`](https://blockchair.com/dogecoin/block/6225155) (Mined 28 May 2026 10:18:48 UTC) isn't marked incorrectly as invalid

**A GPT 5.5 summary of the issue**
The indexer stopped syncing after height `6225154` because the next block, `6225155`, was rejected by the old `dogewalker`/`doge` parser as invalid.

That block is valid Dogecoin mainnet data. Its AuxPoW parent coinbase transaction uses SegWit-style transaction serialisation:

* Block height: `6225155`
* Block hash: `cdb29199d2e6cb9d396d5f75f6335cd695dd05278d07dc07eadbfc49f14efc44`
* The AuxPoW transaction starts with the SegWit marker/flag pattern `0001`
* The AuxPoW coinbase input includes `txinwitness`
* The AuxPoW parent transaction includes a `witness_v0_keyhash` output and a witness commitment `OP_RETURN aa21a9ed...`

The older `doge` parser did not handle witness data in transactions. When it encountered the witness-serialised AuxPoW coinbase transaction, it misread the byte stream and treated the valid block as malformed.

Updating `dogewalker` brings in a newer `doge` parser with witness-aware transaction decoding, including witness data on transaction inputs. With that update, the indexer can parse this block correctly and continue syncing past height `6225154`.

